### PR TITLE
Update ExcelFinancialFunctions library to version 3.0.0

### DIFF
--- a/src/dexih.functions.financial/dexih.functions.financial.csproj
+++ b/src/dexih.functions.financial/dexih.functions.financial.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="ExcelFinancialFunctions" Version="2.4.1" />
+      <PackageReference Include="ExcelFinancialFunctions" Version="3.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Hi there. ExcelFinancialFunctions has been updated to 3.0.0. This version has been built on NET Standard 2.0, so no more build warnings like this:

```
warning NU1701: Package 'ExcelFinancialFunctions 2.4.1' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8' instead of the project target framework '.NETStandard,Version=v2.1'. This package may not be fully compatible with your project.
warning NU1701: Package 'FSharp.Core 4.0.0.1' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8' instead of the project target framework '.NETStandard,Version=v2.1'. This package may not be fully compatible with your project.
```